### PR TITLE
Fix intermittent crashes in clients where notifications sent by the NORM runtime sometimes contains dangling pointers.

### DIFF
--- a/include/normNode.h
+++ b/include/normNode.h
@@ -29,7 +29,7 @@ class NormNode
         
         NormSession& GetSession() const {return session;}
         void Retain();
-        void Release();
+        bool Release();
         
         void SetUserData(const void* userData)
             {user_data = userData;}

--- a/include/normObject.h
+++ b/include/normObject.h
@@ -48,7 +48,7 @@ class NormObject
         
         virtual ~NormObject();
         void Retain();
-        void Release();
+        bool Release();
         unsigned int GetReferenceCount() {return reference_count;}
         
         // This must be reset after each update

--- a/src/common/normApi.cpp
+++ b/src/common/normApi.cpp
@@ -415,7 +415,10 @@ void NormInstance::PurgeObjectNotifications(NormObjectHandle objectHandle)
         if (objectHandle == next->event.object)
         {
             // "Release" the previously-retained object handle
-            ((NormObject*)objectHandle)->Release();
+            if (((NormObject*)objectHandle)->Release())
+            {
+                next->event.object = NORM_OBJECT_INVALID;
+            }
             // Remove from queue and put in pool
             notify_queue.Remove(*next);
             notify_pool.Append(*next);
@@ -424,7 +427,10 @@ void NormInstance::PurgeObjectNotifications(NormObjectHandle objectHandle)
     if ((NULL != previous_notification) && (objectHandle == previous_notification->event.object))
     {
         // "Release" any previously-retained object or node handle
-        ((NormObject*)(previous_notification->event.object))->Release();
+        if (((NormObject*)(previous_notification->event.object))->Release())
+        {
+            previous_notification->event.object = NORM_OBJECT_INVALID;
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -442,7 +448,10 @@ void NormInstance::PurgeNodeNotifications(NormNodeHandle nodeHandle)
         if (nodeHandle == next->event.sender)
         {
             // "Release" the previously-retained object handle
-            ((NormNode*)nodeHandle)->Release();
+            if (((NormNode*)nodeHandle)->Release())
+            {
+                next->event.sender = NORM_NODE_INVALID;
+            }
             // Remove this notification from queue and return to pool
             notify_queue.Remove(*next);
             notify_pool.Append(*next);
@@ -452,9 +461,19 @@ void NormInstance::PurgeNodeNotifications(NormNodeHandle nodeHandle)
     {
         // "Release" any previously-retained object or node handle
         if (NORM_OBJECT_INVALID != previous_notification->event.object)
-            ((NormObject*)(previous_notification->event.object))->Release();
+        {
+            if (((NormObject*)(previous_notification->event.object))->Release())
+            {
+                previous_notification->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else
-            ((NormNode*)(previous_notification->event.sender))->Release();
+        {
+            if (((NormNode*)(previous_notification->event.sender))->Release())
+            {
+                previous_notification->event.sender = NORM_NODE_INVALID;
+            }
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -470,10 +489,20 @@ void NormInstance::PurgeSessionNotifications(NormSessionHandle sessionHandle)
     {
         if (next->event.session == sessionHandle)
         {
-             if (NORM_OBJECT_INVALID != next->event.object)
-                ((NormObject*)next->event.object)->Release();
+            if (NORM_OBJECT_INVALID != next->event.object)
+            {
+                if (((NormObject*)next->event.object)->Release())
+                {
+                    next->event.object = NORM_OBJECT_INVALID;
+                }
+            }
             else if (NORM_NODE_INVALID != next->event.sender)
-                ((NormNode*)next->event.sender)->Release();
+            {
+                if (((NormNode*)next->event.sender)->Release())
+                {
+                    next->event.sender = NORM_NODE_INVALID;
+                }
+            }
             // Remove this notification from queue and return to pool
             notify_queue.Remove(*next);
             notify_pool.Append(*next);
@@ -483,9 +512,19 @@ void NormInstance::PurgeSessionNotifications(NormSessionHandle sessionHandle)
     {
         // "Release" any previously-retained object or node handle
         if (NORM_OBJECT_INVALID != previous_notification->event.object)
-            ((NormObject*)(previous_notification->event.object))->Release();
+        {
+            if (((NormObject*)(previous_notification->event.object))->Release())
+            {
+                previous_notification->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else if (NORM_NODE_INVALID != previous_notification->event.sender)
-            ((NormNode*)(previous_notification->event.sender))->Release();
+        {
+            if (((NormNode*)(previous_notification->event.sender))->Release())
+            {
+                previous_notification->event.sender = NORM_NODE_INVALID;
+            }
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -504,9 +543,19 @@ void NormInstance::PurgeNotifications(NormSessionHandle sessionHandle, NormEvent
             (next->event.type == eventType))
         {
             if (NORM_OBJECT_INVALID != next->event.object)
-                ((NormObject*)next->event.object)->Release();
+            {
+                if (((NormObject*)next->event.object)->Release())
+                {
+                    next->event.object = NORM_OBJECT_INVALID;
+                }
+            }
             else if (NORM_NODE_INVALID != next->event.sender)
-                ((NormNode*)next->event.sender)->Release();
+            {
+                if (((NormNode*)next->event.sender)->Release())
+                {
+                    next->event.sender = NORM_NODE_INVALID;
+                }
+            }
             // Remove this notification from queue and return to pool
             notify_queue.Remove(*next);
             notify_pool.Append(*next);
@@ -523,9 +572,19 @@ bool NormInstance::GetNextEvent(NormEvent* theEvent)
     {
         // "Release" any previously-retained object or node handle
         if (NORM_OBJECT_INVALID != previous_notification->event.object)
-            ((NormObject*)(previous_notification->event.object))->Release();
+        {
+            if (((NormObject*)(previous_notification->event.object))->Release())
+            {
+                previous_notification->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else if (NORM_NODE_INVALID != previous_notification->event.sender)
-            ((NormNode*)(previous_notification->event.sender))->Release();
+        {
+            if (((NormNode*)(previous_notification->event.sender))->Release())
+            {
+                previous_notification->event.sender = NORM_OBJECT_INVALID;
+            }
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -653,9 +712,19 @@ void NormInstance::ReleasePreviousEvent()
     {
         // Release any previously-retained object or node handles
         if (NORM_OBJECT_INVALID != previous_notification->event.object)
-            ((NormObject*)(previous_notification->event.object))->Release();
+        {
+            if (((NormObject*)(previous_notification->event.object))->Release())
+            {
+                previous_notification->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else if (NORM_NODE_INVALID != previous_notification->event.sender)
-            ((NormNode*)(previous_notification->event.sender))->Release();
+        {
+            if (((NormNode*)(previous_notification->event.sender))->Release())
+            {
+                previous_notification->event.sender = NORM_NODE_INVALID;
+            }
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -701,9 +770,19 @@ void NormInstance::Shutdown()
     {
         // Release any previously-retained object or node handles
         if (NORM_OBJECT_INVALID != previous_notification->event.object)
-            ((NormObject*)(previous_notification->event.object))->Release();
+        {
+            if (((NormObject*)(previous_notification->event.object))->Release())
+                {
+                previous_notification->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else if (NORM_NODE_INVALID != previous_notification->event.sender)
-            ((NormNode*)(previous_notification->event.sender))->Release();
+        {
+            if (((NormNode*)(previous_notification->event.sender))->Release())
+            {
+                previous_notification->event.sender = NORM_NODE_INVALID;
+            }
+        }
         notify_pool.Append(*previous_notification);   
         previous_notification = NULL;   
     }
@@ -730,9 +809,19 @@ void NormInstance::Shutdown()
                 break;
         }   
         if (NORM_OBJECT_INVALID != next->event.object)
-            ((NormObject*)(next->event.object))->Release();
+        {
+            if (((NormObject*)(next->event.object))->Release())
+            {
+                next->event.object = NORM_OBJECT_INVALID;
+            }
+        }
         else if (NORM_NODE_INVALID != next->event.sender)
-            ((NormNode*)(next->event.sender))->Release();
+        {
+            if (((NormNode*)(next->event.sender))->Release())
+            {
+                next->event.sender = NORM_NODE_INVALID;
+            }
+        }
         delete next;        
     }
     notify_pool.Destroy();

--- a/src/common/normNode.cpp
+++ b/src/common/normNode.cpp
@@ -20,15 +20,28 @@ void NormNode::Retain()
     reference_count++;
 }  // end NormNode::Retain()
 
-void NormNode::Release()
+bool NormNode::Release()
 {
     if (reference_count)
+    {
         reference_count--;
+    }
     else
+    {
         PLOG(PL_ERROR, "NormNode::Release() releasing non-retained node?!\n");
-    if (0 == reference_count) delete this;   
-}  // end NormNode::Release()
+        //
+        // Invalid refcount is a fatal programmer error. Crash now and get it fixed.
+        //
+        __fastfail(FAST_FAIL_INVALID_REFERENCE_COUNT);
+    }
 
+    if (0 == reference_count) {
+        delete this;
+        return true;
+    }
+
+    return false;
+}  // end NormNode::Release()
 
 const NormNodeId& NormNode::LocalNodeId() const 
     {return session.LocalNodeId();}

--- a/src/common/normObject.cpp
+++ b/src/common/normObject.cpp
@@ -48,9 +48,8 @@ void NormObject::Retain()
     if (sender) sender->Retain();
 }  // end NormObject::Retain()
 
-void NormObject::Release()
+bool NormObject::Release()
 {
-    if (sender) sender->Release();
     if (reference_count)
     {
         reference_count--;
@@ -58,8 +57,18 @@ void NormObject::Release()
     else
     {
         PLOG(PL_ERROR, "NormObject::Release() releasing non-retained object?!\n");
+        //
+        // Invalid refcount is a fatal programmer error. Crash now and get it fixed.
+        //
+        __fastfail(FAST_FAIL_INVALID_REFERENCE_COUNT);
     }
-    if (0 == reference_count) delete this;
+
+    if (0 == reference_count) {
+        delete this;
+        return true;
+    }
+
+    return false;
 }  // end NormObject::Release()
 
 // This is mainly used for debug messages


### PR DESCRIPTION
Fix intermittent crashes in clients where notifications sent by the NORM runtime sometimes contains dangling pointers. The fix consists in nulling the pointers after the objects being pointed to have been release, if the release operation rsulted in the deletion of said objects.